### PR TITLE
Nugget RN v1.1.4

### DIFF
--- a/ios/NuggetRN.swift
+++ b/ios/NuggetRN.swift
@@ -133,9 +133,31 @@ class NuggetRN: RCTEventEmitter {
   }
 
   @objc
-    func sendNotificationPayload(_ payload: NSDictionary) {
-
+  func sendNotificationPayload(_ payload: NSDictionary) {
+    // Keep only string-valued entries, then hand off for handling.
+    var result = [String: String]()
+    for case let (key as String, value) in payload {
+      if let stringValue = value as? String {
+        result[key] = stringValue
+      }
     }
+
+    handleNotificationPayload(result)
+  }
+
+  private func handleNotificationPayload(_ payload: [String: String]) {
+    guard !payload.isEmpty,
+          NuggetNotificationManager.isChatSdkNotification(payload) else { return }
+    
+    // The SDK builds & presents the in-app notification UI; on tap we fire the
+    // deeplink directly so the host app's URL handler can route it.
+    NuggetNotificationManager.shared.generateNotification(payload: payload) { [weak self] deeplink in
+      Task { @MainActor in
+        guard let url = URL(string: deeplink), UIApplication.shared.canOpenURL(url) else { return }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+      }
+    }
+  }
 
   @objc
   func updateNotificationToken(_ token: String) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nugget-rn",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "react native plugin for nugget android and ios",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary
- Bump `nugget-rn` to **v1.1.4** (`package.json`)
- iOS: handle incoming notification payloads in `NuggetRN.sendNotificationPayload` — filter to string-valued entries, then route Nugget chat-SDK notifications through `NuggetNotificationManager`, opening the returned deeplink via the host app's URL handler
- iOS: update `chatSupportBusinessContext` completion to use the friendly `NuggetChatBusinessContext` typealias instead of the raw `ZChatBusinessContext`

## Test plan
- [ ] Build the iOS `example/` app and verify a chat-SDK push payload presents the in-app notification and the deeplink opens on tap
- [ ] Verify non-chat / empty payloads are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)