### PR TITLE
Theme ID handling for iOS — v1.1.4

### DIFF
--- a/android/src/main/java/com/nuggetrn/NuggetRN.kt
+++ b/android/src/main/java/com/nuggetrn/NuggetRN.kt
@@ -143,8 +143,7 @@ class NuggetRN(private val reactContext: ReactApplicationContext) :
               ticketGroupingId = ticketGroupingId,
               ticketID = ticketID,
               ticketProperties = ticketProperties,
-              botProperties = botProperties,
-              themeId = themeId
+              botProperties = botProperties
             )
           }
 

--- a/android/src/main/java/com/nuggetrn/NuggetRN.kt
+++ b/android/src/main/java/com/nuggetrn/NuggetRN.kt
@@ -143,7 +143,8 @@ class NuggetRN(private val reactContext: ReactApplicationContext) :
               ticketGroupingId = ticketGroupingId,
               ticketID = ticketID,
               ticketProperties = ticketProperties,
-              botProperties = botProperties
+              botProperties = botProperties,
+              themeId = themeId
             )
           }
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -23,7 +23,7 @@ flipper_config = FlipperConfiguration.disabled
 target 'NuggetRNExample' do
   config = use_native_modules!
 
-  pod 'NuggetSDK', :git => 'https://github.com/Zomato-Nugget/nugget-sdk-ios.git', :tag => '4.5.28'
+  pod 'NuggetSDK', :git => 'https://github.com/Zomato-Nugget/nugget-sdk-ios.git', :tag => '4.5.33'
   use_react_native!(
     :path => config[:reactNativePath],
     # Enables Flipper.

--- a/ios/NuggetRN.m
+++ b/ios/NuggetRN.m
@@ -16,7 +16,7 @@ RCT_EXTERN_METHOD(initializeNuggetFactory:(NSDictionary *)sdkConfiguration
                   darkModeAccentColorData:(NSDictionary *)darkModeAccentColorData
                   fontData:(NSDictionary *)fontData
                   isDarkModeEnabled:(nonnull NSNumber *)isDarkModeEnabled
-                  shouldToggleThemeDelegate:(NSNumber *)shouldToggleThemeDelegate)
+                  shouldToggleThemeDelegate:(nonnull NSNumber *)shouldToggleThemeDelegate)
 
 RCT_EXTERN_METHOD(onJsResponse:(NSString *)method result:(id)result)
 

--- a/ios/NuggetRN.swift
+++ b/ios/NuggetRN.swift
@@ -9,17 +9,20 @@ fileprivate struct ClientSideNuggetChatBusinessContext: NuggetChatBusinessContex
   var ticketGroupingId: String?
   var ticketProperties: [String : [String]]?
   var botProperties: [String : [String]]?
+  var themeId: String? 
 
   init(channelHandle: String? = nil,
        ticketID: Int? = nil,
        ticketGroupingId: String? = nil,
        ticketProperties: [String : [String]]? = nil,
-       botProperties: [String : [String]]? = nil) {
+       botProperties: [String : [String]]? = nil,
+       themeId: String? = nil) {
     self.channelHandle = channelHandle
     self.ticketID = ticketID
     self.ticketGroupingId = ticketGroupingId
     self.ticketProperties = ticketProperties
     self.botProperties = botProperties
+    self.themeId = themeId
   }
 }
 
@@ -36,11 +39,13 @@ fileprivate class ClientSideNuggetChatBusinessContextProvider: NuggetBusinessCon
     let ticketProperties: [String: [String]]? = params["ticketProperties"] as? [String: [String]]
     let ticketID: Int? = params["ticketID"] as? Int
     let botProperties: [String: [String]]? = params["botProperties"] as? [String: [String]]
+    let themeId: String? = params["ticketGroupingId"] as? String
     return ClientSideNuggetChatBusinessContext(channelHandle: channelHandle,
                                                ticketID: ticketID,
                                                ticketGroupingId: ticketGroupingId,
                                                ticketProperties: ticketProperties,
-                                               botProperties: botProperties)
+                                               botProperties: botProperties,
+                                               themeId: themeId)
   }
 
   func chatSupportBusinessContext() -> NuggetChatBusinessContext {

--- a/ios/NuggetRN.swift
+++ b/ios/NuggetRN.swift
@@ -39,7 +39,7 @@ fileprivate class ClientSideNuggetChatBusinessContextProvider: NuggetBusinessCon
     let ticketProperties: [String: [String]]? = params["ticketProperties"] as? [String: [String]]
     let ticketID: Int? = params["ticketID"] as? Int
     let botProperties: [String: [String]]? = params["botProperties"] as? [String: [String]]
-    let themeId: String? = params["ticketGroupingId"] as? String
+    let themeId: String? = params["themeId"] as? String
     return ClientSideNuggetChatBusinessContext(channelHandle: channelHandle,
                                                ticketID: ticketID,
                                                ticketGroupingId: ticketGroupingId,

--- a/ios/NuggetRN.swift
+++ b/ios/NuggetRN.swift
@@ -39,7 +39,7 @@ fileprivate class ClientSideNuggetChatBusinessContextProvider: NuggetBusinessCon
     let ticketProperties: [String: [String]]? = params["ticketProperties"] as? [String: [String]]
     let ticketID: Int? = params["ticketID"] as? Int
     let botProperties: [String: [String]]? = params["botProperties"] as? [String: [String]]
-    let themeId: String? = params["themeId"] as? String
+    let themeId: String? = params["themeID"] as? String
     return ClientSideNuggetChatBusinessContext(channelHandle: channelHandle,
                                                ticketID: ticketID,
                                                ticketGroupingId: ticketGroupingId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nugget-rn",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "react native plugin for nugget android and ios",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
iOS `themeId` handling in chat business context + NuggetSDK bump to 4.5.33. Bumps `nugget-rn` to v1.1.4. Verified the iOS example app builds clean (native + production JS bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)